### PR TITLE
change how we read excel sheets so that duplicate columns are allowed

### DIFF
--- a/R/ReadEMODResults.R
+++ b/R/ReadEMODResults.R
@@ -107,7 +107,7 @@ read.ingest.sheet <- function(ingest_filename, sheet) {
   raw_data <- read_excel(ingest_filename, sheet)
   first_row <- last(which(raw_data[,1] == 'Year'))
   instrument_name <- names(raw_data)[2]
-  sheet_data <- read_excel(ingest_filename, sheet, skip = first_row)
+  sheet_data <- read_excel(ingest_filename, sheet, skip = first_row, .name_repair = "minimal")
   if (any(names(sheet_data) == "two_sigma")) {
     bounds <- calculate.bounds.two_sigma(sheet_data[,instrument_name], sheet_data$two_sigma)
     print(bounds)


### PR DESCRIPTION
Should fix issue #17 . Ingest files with duplicate column names would rename columns to be unique. Now column names are not renames. If duplicate columns exist and you index on that column, the first instance of that column will be returned.